### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/entry.py
+++ b/entry.py
@@ -69,7 +69,7 @@ class Entry:
             if wikilang == 'en':
                 entry += meanings[0].term.wikiWrapAsExample(wikilang) + '\n\n'
                 for meaning in meanings:
-                    entry += '#%s %s\n' % (meaning.getLabel(),
+                    entry += '#{0!s} {1!s}\n'.format(meaning.getLabel(),
                                            meaning.definition)
                     entry += meaning.wikiWrapExamples()
                 entry += '\n'
@@ -78,25 +78,25 @@ class Entry:
                 for meaning in meanings:
                     term = meaning.term
                     entry += meaning.getLabel() + term.wikiWrapAsExample(
-                        wikilang) + '; %s\n' % meaning.definition
+                        wikilang) + '; {0!s}\n'.format(meaning.definition)
                     entry += meaning.wikiWrapExamples()
                 entry += '\n'
 
             if meaning.hasSynonyms():
-                entry += '%s\n' % (
-                    structs.wiktionaryformats[wikilang]['synonymsheader'])
+                entry += '{0!s}\n'.format((
+                    structs.wiktionaryformats[wikilang]['synonymsheader']))
                 for meaning in meanings:
-                    entry += "*%s'''%s''': %s" % (meaning.getLabel(),
+                    entry += "*{0!s}'''{1!s}''': {2!s}".format(meaning.getLabel(),
                                                   meaning.getConciseDef(),
                                                   meaning.wikiWrapSynonyms(
                                                       wikilang))
                 entry += '\n'
 
             if meaning.hasTranslations():
-                entry += '%s\n' % (
-                    structs.wiktionaryformats[wikilang]['translationsheader'])
+                entry += '{0!s}\n'.format((
+                    structs.wiktionaryformats[wikilang]['translationsheader']))
                 for meaning in meanings:
-                    entry += "%s'''%s'''\n%s\n\n" % (
+                    entry += "{0!s}'''{1!s}'''\n{2!s}\n\n".format(
                         meaning.getLabel(), meaning.getConciseDef(),
                         meaning.wikiWrapTranslations(wikilang, self.entrylang))
                 entry += '\n'
@@ -108,7 +108,7 @@ class Entry:
         The primary purpose is to help keep your sanity while debugging.
 
         """
-        print ' ' * indentation + 'entrylang = %s' % self.entrylang
+        print ' ' * indentation + 'entrylang = {0!s}'.format(self.entrylang)
         print ' ' * indentation + 'posorder:' + repr(self.posorder)
 
         meaningkeys = self.meanings.keys()

--- a/header.py
+++ b/header.py
@@ -73,5 +73,5 @@ class Header(object):
             self.contents = otherheaders[self.header]
 
     def __repr__(self):
-        return "%s.Header(contents='%s', header='%s', level=%d, type='%s')" % (
+        return "{0!s}.Header(contents='{1!s}', header='{2!s}', level={3:d}, type='{4!s}')".format(
             self.__module__, self.contents, self.header, self.level, self.type)

--- a/meaning.py
+++ b/meaning.py
@@ -316,7 +316,7 @@ class Meaning:
 
     def getLabel(self):
         if self.label:
-            return u'<!--%s-->' % self.label
+            return u'<!--{0!s}-->'.format(self.label)
 
     def setConciseDef(self, concisedef):
         self.concisedef = concisedef
@@ -394,8 +394,8 @@ class Meaning:
             # current Wiktionary
             alllanguages = self.translations.keys()
             alllanguages.sort(sortonname(langnames[wikilang]))
-            wrappedtranslations = '%s\n' % (
-                structs.wiktionaryformats[wikilang]['transbefore'])
+            wrappedtranslations = '{0!s}\n'.format((
+                structs.wiktionaryformats[wikilang]['transbefore']))
             alreadydone = 0
             for language in alllanguages:
                 if language == wikilang:
@@ -458,8 +458,8 @@ class Meaning:
         """
         print ' ' * indentation + 'term: '
         self.term.showContents(indentation + 2)
-        print ' ' * indentation + 'definition = %s' % self.definition
-        print ' ' * indentation + 'etymology = %s' % self.etymology
+        print ' ' * indentation + 'definition = {0!s}'.format(self.definition)
+        print ' ' * indentation + 'etymology = {0!s}'.format(self.etymology)
         print ' ' * indentation + 'Synonyms:'
         for synonym in self.synonyms:
             synonym.showContents(indentation + 2)
@@ -476,5 +476,5 @@ class Meaning:
         """
         wrappedexamples = ''
         for example in self.examples:
-            wrappedexamples += "#:'''%s'''\n" % example
+            wrappedexamples += "#:'''{0!s}'''\n".format(example)
         return wrappedexamples

--- a/term.py
+++ b/term.py
@@ -93,9 +93,9 @@ class Term(object):
 
         """
         if self.gender:
-            return ' %s' % (
+            return ' {0!s}'.format((
                 structs.wiktionaryformats[wikilang]['gender'].replace(
-                    '%%gender%%', self.gender))
+                    '%%gender%%', self.gender)))
         else:
             return ''
 
@@ -113,14 +113,14 @@ class Term(object):
         in a format ready for Wiktionary
 
         """
-        return '[[%s]]' % self.term
+        return '[[{0!s}]]'.format(self.term)
 
     def wikiWrapAsTranslation(self, wikilang):
         """  Returns a string with this term as a link followed by the gender
         in a format ready for Wiktionary
 
         """
-        return '[[%s]]' % self.term
+        return '[[{0!s}]]'.format(self.term)
 
     def showContents(self, indentation):
         """ Prints the contents of this Term.
@@ -128,10 +128,10 @@ class Term(object):
         The primary purpose is to help keep one's sanity while debugging.
 
         """
-        print ' ' * indentation + 'lang = %s' % self.lang
-        print ' ' * indentation + 'pos = %s' % self.pos
-        print ' ' * indentation + 'term = %s' % self.term
-        print ' ' * indentation + 'relatedwords = %s' % self.relatedwords
+        print ' ' * indentation + 'lang = {0!s}'.format(self.lang)
+        print ' ' * indentation + 'pos = {0!s}'.format(self.pos)
+        print ' ' * indentation + 'term = {0!s}'.format(self.term)
+        print ' ' * indentation + 'relatedwords = {0!s}'.format(self.relatedwords)
 
 
 class Noun(Term):
@@ -154,7 +154,7 @@ class Noun(Term):
 
     def showContents(self, indentation):
         Term.showContents(self, indentation)
-        print ' ' * indentation + 'gender = %s' % self.gender
+        print ' ' * indentation + 'gender = {0!s}'.format(self.gender)
 
     def wikiWrapAsExample(self, wikilang):
         """ Returns a string with the gender in a format ready for Wiktionary,
@@ -229,7 +229,7 @@ class Verb(Term):
         """
         if wikilang == 'en':
             if self.term.lower().startswith('to '):
-                return 'to [[%s]]' % self.term[3:]
+                return 'to [[{0!s}]]'.format(self.term[3:])
         return Term.wikiWrapForList(self, wikilang)
 
     def wikiWrapAsTranslation(self, wikilang):

--- a/wiktionarypage.py
+++ b/wiktionarypage.py
@@ -412,7 +412,7 @@ class WiktionaryPage:
                                         "'", '').replace(":", '').replace(
                                             ".", '').replace("#", '').lower()
                                 if len(word) > 1 and \
-                                   ' %s ' % word in definition:
+                                   ' {0!s} '.format(word) in definition:
                                     score += 1
                                 if len(word) > 2 and word in definition:
                                     score += 1
@@ -474,9 +474,9 @@ class WiktionaryPage:
 
         """
         indentation = 0
-        print ' ' * indentation + 'wikilang = %s' % self.wikilang
+        print ' ' * indentation + 'wikilang = {0!s}'.format(self.wikilang)
 
-        print ' ' * indentation + 'term = %s' % self.term
+        print ' ' * indentation + 'term = {0!s}'.format(self.term)
 
         entrieskeys = self.entries.keys()
         for entrieskey in entrieskeys:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pywikibot-wiktionary?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pywikibot-wiktionary?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
